### PR TITLE
fix: update property name for GITLAB_SBOM_PUSH_ENABLED

### DIFF
--- a/src/views/administration/integrations/GitLab.vue
+++ b/src/views/administration/integrations/GitLab.vue
@@ -140,7 +140,7 @@ export default {
         case 'gitlab.enabled':
           this.isGitlabEnabled = common.toBoolean(item.propertyValue);
           break;
-        case 'sbom.push.enabled':
+        case 'gitlab.sbom.push.enabled':
           this.sbomEnabled = common.toBoolean(item.propertyValue);
           break;
         case 'gitlab.include.archived':
@@ -219,7 +219,7 @@ export default {
         this.updateConfigProperties([
           {
             groupName: 'integrations',
-            propertyName: 'sbom.push.enabled',
+            propertyName: 'gitlab.sbom.push.enabled',
             propertyValue: this.sbomEnabled,
           },
           {


### PR DESCRIPTION
### Description

Updates the sbom push propertyName to be more descriptive.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
